### PR TITLE
chore(bower) update ignore syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "ignore": [
-      "*.log"
+      "*.log",
       "*.DS_Store",
       ".git",
       ".gitignore",


### PR DESCRIPTION
The latest update caused the error:

> bower adm-dtp#*                                  EMALFORMED Failed to read /tmp/edba32fea673d6e68dc9d72eb1770416/bower/8108e4c31be1270e66d15b6d55648851-237-7JpAtm/bower.json
> 
> Additional error details:
> Unexpected string in JSON at position 570